### PR TITLE
fixing platform setting for test projects

### DIFF
--- a/GuessMyNumber/GuessMyNumber.Tests/GuessMyNumber.Tests.csproj
+++ b/GuessMyNumber/GuessMyNumber.Tests/GuessMyNumber.Tests.csproj
@@ -18,6 +18,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>


### PR DESCRIPTION
The GuessMyNumber.Test assembly was set to anyCPU, but the assembly to be tested was set to x86. Therefore some adaptions were needed.